### PR TITLE
feat(quickjs): embed bytecode blob in binary (V82JSC_BC_BLOB)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,29 @@
 use std::env;
 use std::path::PathBuf;
 
+/// Emit `$OUT_DIR/bc_embed.rs` defining `EMBEDDED_BC`. When `V82JSC_BC_BLOB`
+/// points at a packed bytecode blob (see `module.rs` for the format), its bytes
+/// are `include_bytes!`'d straight into the binary so startup reads compiled
+/// module bytecode from memory instead of the on-disk cache. Absent the env
+/// var, `EMBEDDED_BC` is empty and the disk cache path is used as before.
+fn emit_bc_embed() {
+  let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+  let dst = out_dir.join("bc_embed.rs");
+  println!("cargo:rerun-if-env-changed=V82JSC_BC_BLOB");
+  let body = match env::var_os("V82JSC_BC_BLOB") {
+    Some(p) if PathBuf::from(&p).is_file() => {
+      let p = PathBuf::from(&p);
+      println!("cargo:rerun-if-changed={}", p.display());
+      format!(
+        "pub static EMBEDDED_BC: &[u8] = include_bytes!(r\"{}\");",
+        p.display()
+      )
+    }
+    _ => "pub static EMBEDDED_BC: &[u8] = &[];".to_string(),
+  };
+  std::fs::write(&dst, body).unwrap();
+}
+
 fn main() {
   let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
@@ -27,6 +50,8 @@ fn main() {
     binding_path.display()
   );
   println!("cargo:rerun-if-changed={}", binding_path.display());
+
+  emit_bc_embed();
 
   // --- JSC backend: generate full FFI bindings from the SDK header. ---
   // `src/jsc_sys.rs` `include!`s the output, so the complete JavaScriptCore

--- a/src/quickjs/module.rs
+++ b/src/quickjs/module.rs
@@ -109,7 +109,44 @@ fn bc_path(key: u64) -> Option<std::path::PathBuf> {
   Some(bc_cache_dir()?.join(format!("{key:016x}.qbc")))
 }
 
+// Build-time embedded bytecode blob (empty unless V82JSC_BC_BLOB was set at
+// build). Defines `EMBEDDED_BC: &[u8]`. Blob format: [count u32 LE] then
+// `count` entries of [key u64 LE][len u32 LE][bytes]. Lets a shipped binary
+// carry precompiled module bytecode instead of warming an on-disk cache.
+include!(concat!(env!("OUT_DIR"), "/bc_embed.rs"));
+
+fn embedded_bc() -> &'static HashMap<u64, &'static [u8]> {
+  use std::sync::OnceLock;
+  static M: OnceLock<HashMap<u64, &'static [u8]>> = OnceLock::new();
+  M.get_or_init(|| {
+    let mut m = HashMap::new();
+    let b = EMBEDDED_BC;
+    if b.len() >= 4 {
+      let count = u32::from_le_bytes(b[0..4].try_into().unwrap()) as usize;
+      let mut off = 4usize;
+      for _ in 0..count {
+        if off + 12 > b.len() {
+          break;
+        }
+        let key = u64::from_le_bytes(b[off..off + 8].try_into().unwrap());
+        let len =
+          u32::from_le_bytes(b[off + 8..off + 12].try_into().unwrap()) as usize;
+        off += 12;
+        if off + len > b.len() {
+          break;
+        }
+        m.insert(key, &b[off..off + len]);
+        off += len;
+      }
+    }
+    m
+  })
+}
+
 pub(crate) fn bc_load(key: u64) -> Option<Vec<u8>> {
+  if let Some(&bytes) = embedded_bc().get(&key) {
+    return Some(bytes.to_vec());
+  }
   let p = bc_path(key)?;
   std::fs::read(p).ok().filter(|b| !b.is_empty())
 }


### PR DESCRIPTION
## What

Lets a shipped deno-on-quickjs binary carry its **precompiled module bytecode baked in**, instead of warming an on-disk cache (`~/Library/Caches/v82jsc_bc/*.qbc`).

- `build.rs` `include_bytes!`s a packed `{key -> bytecode}` blob when `V82JSC_BC_BLOB` points at one (else empty → disk path unchanged).
- `bc_load` checks the embedded map before the disk cache.
- **Fully transparent**: no new C-ABI symbols, no embedder/deno changes.

## Blob format

`[count u32 LE]` then `count` × `[key u64 LE][len u32 LE][bytes]`. Generate by warming the disk cache once, then packing the `.qbc` files.

## Why

For the no-snapshot deno-on-quickjs path (New-init boot + bytecode cache as the 'snapshot'), this makes the binary self-contained — verified booting with the disk cache deleted and disabled, serving all module bytecode from the baked-in blob. Next.js 14 dev (SSR + SWC) runs on the resulting binary.

Claude-Session: https://claude.ai/code/session_01YMXKXxuW3tgs96FpbpKYqU