### PR TITLE
fix(build): support Deno Windows release targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,35 @@ jobs:
       # Link a test executable, not just an rlib, so CRT mismatches in WAMR's
       # static archive are caught here rather than in downstream binaries.
       - name: Link --lib test executable (quickjs)
-        run: cargo test --no-default-features --features quickjs --lib --no-run
+        shell: pwsh
+        run: |
+          $lockJob = $null
+          if ("${{ matrix.arch }}" -eq "x86_64" -and "${{ matrix.crt }}" -eq "dynamic") {
+            $stalePath = (Resolve-Path ".git/modules/vendor/rusty_v8/stale-cache-entry").Path
+            $lockJob = Start-Job -ScriptBlock {
+              param($path)
+              $stream = [System.IO.File]::Open(
+                $path,
+                [System.IO.FileMode]::Open,
+                [System.IO.FileAccess]::Read,
+                [System.IO.FileShare]::None
+              )
+              Write-Output "locked"
+              Start-Sleep -Seconds 3
+              $stream.Dispose()
+            } -ArgumentList $stalePath
+            while (@(Receive-Job -Job $lockJob -Keep) -notcontains "locked") {
+              Start-Sleep -Milliseconds 50
+            }
+          }
+
+          cargo test --no-default-features --features quickjs --lib --no-run
+          $cargoExit = $LASTEXITCODE
+          if ($null -ne $lockJob) {
+            Wait-Job -Job $lockJob | Out-Null
+            Remove-Job -Job $lockJob -Force
+          }
+          exit $cargoExit
 
   # ---------------------------------------------------------------------------
   # deno_core test suite per backend: clone+patch deno, `cargo nextest run -p

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,27 @@ jobs:
   # atomics for quickjs, multi-config cmake for WAMR).
   # ---------------------------------------------------------------------------
   windows-build:
-    name: check-quickjs-windows
-    runs-on: windows-latest
+    name: check-quickjs-windows-${{ matrix.arch }}-${{ matrix.crt }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            crt: dynamic
+            runner: windows-2022
+            rustflags: ""
+          - arch: x86_64
+            crt: static
+            runner: windows-2022
+            rustflags: "-C target-feature=+crt-static"
+          - arch: aarch64
+            crt: static
+            runner: windows-11-arm
+            rustflags: "-C target-feature=+crt-static"
+    env:
+      RUSTFLAGS: ${{ matrix.rustflags }}
     steps:
       # Git for Windows defaults to core.autocrlf=true, which corrupts the
       # git-binary-delta patches at checkout and CRLFs the submodule trees the
@@ -133,12 +151,21 @@ jobs:
           submodules: false
       - name: Init submodules
         run: git submodule update --init --depth 1 vendor/rusty_v8 vendor/quickjs-ng vendor/wamr
+      - name: Simulate stale Cargo git checkout
+        if: matrix.arch == 'x86_64' && matrix.crt == 'dynamic'
+        shell: pwsh
+        run: |
+          New-Item -ItemType File .cargo-ok
+          Remove-Item vendor/rusty_v8/.git
+          Remove-Item -Recurse -Force .git/modules/vendor/rusty_v8
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          key: check-quickjs-windows
-      - name: Build --lib (quickjs)
-        run: cargo build --no-default-features --features quickjs --lib
+          key: check-quickjs-windows-${{ matrix.arch }}-${{ matrix.crt }}
+      # Link a test executable, not just an rlib, so CRT mismatches in WAMR's
+      # static archive are caught here rather than in downstream binaries.
+      - name: Link --lib test executable (quickjs)
+        run: cargo test --no-default-features --features quickjs --lib --no-run
 
   # ---------------------------------------------------------------------------
   # deno_core test suite per backend: clone+patch deno, `cargo nextest run -p

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,10 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType File .cargo-ok
-          Remove-Item vendor/rusty_v8/.git
-          Remove-Item -Recurse -Force .git/modules/vendor/rusty_v8
+          New-Item -ItemType Directory -Force vendor/rusty_v8
+          Set-Content vendor/rusty_v8/stale-cache-entry "stale worktree"
+          New-Item -ItemType Directory -Force .git/modules/vendor/rusty_v8
+          Set-Content .git/modules/vendor/rusty_v8/stale-cache-entry "stale metadata"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,8 +172,9 @@ jobs:
           $lockJob = $null
           if ("${{ matrix.arch }}" -eq "x86_64" -and "${{ matrix.crt }}" -eq "dynamic") {
             $stalePath = (Resolve-Path ".git/modules/vendor/rusty_v8/stale-cache-entry").Path
+            $worktreePath = (Resolve-Path "vendor/rusty_v8").Path
             $lockJob = Start-Job -ScriptBlock {
-              param($path)
+              param($path, $worktree)
               $stream = [System.IO.File]::Open(
                 $path,
                 [System.IO.FileMode]::Open,
@@ -181,9 +182,12 @@ jobs:
                 [System.IO.FileShare]::None
               )
               Write-Output "locked"
+              while ([System.IO.Directory]::Exists($worktree)) {
+                Start-Sleep -Milliseconds 50
+              }
               Start-Sleep -Seconds 3
               $stream.Dispose()
-            } -ArgumentList $stalePath
+            } -ArgumentList $stalePath, $worktreePath
             while (@(Receive-Job -Job $lockJob -Keep) -notcontains "locked") {
               Start-Sleep -Milliseconds 50
             }

--- a/build.rs
+++ b/build.rs
@@ -220,6 +220,27 @@ fn run_git(cwd: &Path, args: &[&str]) -> bool {
     .unwrap_or(false)
 }
 
+fn remove_stale_submodule_dir(path: &Path) {
+  for attempt in 1..=30 {
+    match std::fs::remove_dir_all(path) {
+      Ok(()) => return,
+      Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+      Err(_) if attempt < 30 => {
+        if attempt == 1 {
+          println!(
+            "cargo:warning=waiting to clear stale Cargo submodule state: {}",
+            path.display()
+          );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+      }
+      Err(err) => {
+        panic!("failed to remove stale {}: {err}", path.display())
+      }
+    }
+  }
+}
+
 fn initialize_submodule(root: &Path, sub: &str) {
   let update_cfg = format!("submodule.{sub}.update=checkout");
   let update = || {
@@ -256,11 +277,7 @@ fn initialize_submodule(root: &Path, sub: &str) {
   );
   println!("cargo:warning=repairing stale Cargo submodule checkout: {sub}");
   for stale in [root.join(sub), root.join(".git/modules").join(sub)] {
-    if stale.exists() {
-      std::fs::remove_dir_all(&stale).unwrap_or_else(|err| {
-        panic!("failed to remove stale {}: {err}", stale.display())
-      });
-    }
+    remove_stale_submodule_dir(&stale);
   }
   let index_lock = root.join(".git/modules").join(sub).join("index.lock");
   for attempt in 1..=3 {

--- a/build.rs
+++ b/build.rs
@@ -262,8 +262,24 @@ fn initialize_submodule(root: &Path, sub: &str) {
       });
     }
   }
-  assert!(
-    update(),
+  let index_lock = root.join(".git/modules").join(sub).join("index.lock");
+  for attempt in 1..=3 {
+    if update() {
+      return;
+    }
+    // Git for Windows may return before a failed submodule helper has removed
+    // the lock it recreated in the freshly initialized module directory.
+    // Once the update has failed, this lock is stale and safe to clear inside
+    // the already-guarded Cargo checkout repair path.
+    if index_lock.is_file() {
+      println!("cargo:warning=clearing stale Cargo submodule lock: {sub}");
+      let _ = std::fs::remove_file(&index_lock);
+    }
+    if attempt < 3 {
+      std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+  }
+  panic!(
     "git submodule update --init {sub} failed after clearing Cargo cache state"
   );
 }

--- a/build.rs
+++ b/build.rs
@@ -220,33 +220,61 @@ fn run_git(cwd: &Path, args: &[&str]) -> bool {
     .unwrap_or(false)
 }
 
+fn initialize_submodule(root: &Path, sub: &str) {
+  let update_cfg = format!("submodule.{sub}.update=checkout");
+  let update = || {
+    // core.autocrlf=false: the patches are made against LF trees; a Windows
+    // clone with the Git for Windows default (autocrlf=true) would otherwise
+    // check the submodule out with CRLF and every patch context would miss.
+    // (-c propagates to the spawned clone/checkout via GIT_CONFIG_PARAMETERS.)
+    run_git(
+      root,
+      &[
+        "-c",
+        "core.autocrlf=false",
+        "-c",
+        &update_cfg,
+        "submodule",
+        "update",
+        "--init",
+        sub,
+      ],
+    )
+  };
+  if update() {
+    return;
+  }
+
+  // Cargo marks its managed git checkouts with `.cargo-ok`. Restored Cargo
+  // caches can retain a populated submodule worktree after its `.git` file or
+  // module metadata has gone stale, making `git submodule update` refuse the
+  // non-empty destination. Only in a Cargo-owned checkout, discard both stale
+  // halves and retry from the pinned gitlink.
+  assert!(
+    root.join(".cargo-ok").is_file(),
+    "git submodule update --init {sub} failed"
+  );
+  println!("cargo:warning=repairing stale Cargo submodule checkout: {sub}");
+  for stale in [root.join(sub), root.join(".git/modules").join(sub)] {
+    if stale.exists() {
+      std::fs::remove_dir_all(&stale).unwrap_or_else(|err| {
+        panic!("failed to remove stale {}: {err}", stale.display())
+      });
+    }
+  }
+  assert!(
+    update(),
+    "git submodule update --init {sub} failed after clearing Cargo cache state"
+  );
+}
+
 /// Apply every patches/<prefix>-NN-*.patch onto a submodule, ordered like
 /// `sort -V` (numerically by NN, then by name). Initializes the submodule
 /// first if its working tree is absent.
 fn apply_patch_series(root: &Path, sub: &str, prefix: &str) {
   let sub_dir = root.join(sub);
   if !sub_dir.join(".git").exists() {
-    let update_cfg = format!("submodule.{sub}.update=checkout");
-    // core.autocrlf=false: the patches are made against LF trees; a Windows
-    // clone with the Git for Windows default (autocrlf=true) would otherwise
-    // check the submodule out with CRLF and every patch context would miss.
-    // (-c propagates to the spawned clone/checkout via GIT_CONFIG_PARAMETERS.)
-    assert!(
-      run_git(
-        root,
-        &[
-          "-c",
-          "core.autocrlf=false",
-          "-c",
-          &update_cfg,
-          "submodule",
-          "update",
-          "--init",
-          sub
-        ]
-      ),
-      "git submodule update --init {sub} failed"
-    );
+    initialize_submodule(root, sub);
   }
   let stamp_dir = sub_dir.join(".v8x-patches");
   std::fs::create_dir_all(&stamp_dir).unwrap();
@@ -401,6 +429,9 @@ fn build_wamr(manifest_dir: &std::path::Path) {
   // disable) always take effect.
   let _ = std::fs::remove_dir_all(&out);
   std::fs::create_dir_all(&out).unwrap();
+  let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+  let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+  let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
   let cmake = |args: &[&str]| {
     let status = std::process::Command::new("cmake")
       .args(args)
@@ -409,15 +440,51 @@ fn build_wamr(manifest_dir: &std::path::Path) {
       .expect("cmake not found — needed to build WAMR");
     assert!(status.success(), "cmake step failed: {args:?}");
   };
-  cmake(&[
-    "-DCMAKE_BUILD_TYPE=Release",
-    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+  let mut configure_args = vec![
+    "-DCMAKE_BUILD_TYPE=Release".to_string(),
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5".to_string(),
     // WAMR's hardware bound-check installs SIGSEGV/SIGBUS handlers that fight
     // Rust's stack-overflow guard (instant abort). Force software checks.
-    "-DWAMR_DISABLE_HW_BOUND_CHECK=1",
-    "-DWAMR_DISABLE_STACK_HW_BOUND_CHECK=1",
-    src.to_str().unwrap(),
-  ]);
+    "-DWAMR_DISABLE_HW_BOUND_CHECK=1".to_string(),
+    "-DWAMR_DISABLE_STACK_HW_BOUND_CHECK=1".to_string(),
+  ];
+  if let Some(target) = match target_arch.as_str() {
+    "aarch64" => Some("AARCH64"),
+    "x86_64" => Some("X86_64"),
+    "x86" => Some("X86_32"),
+    _ => None,
+  } {
+    // CMake reports the host architecture for some generators and spells
+    // native Windows ARM64 differently than WAMR expects. Cargo's target is
+    // authoritative for both native and cross builds.
+    configure_args.push(format!("-DWAMR_BUILD_TARGET={target}"));
+  }
+  if target_os == "windows" && target_env == "msvc" && target_arch == "aarch64"
+  {
+    // Visual Studio's ASM_MASM integration invokes x86 MASM even for native
+    // ARM64 projects and ignores WAMR's armasm64 compiler override. Use WAMR's
+    // portable native-call bridge so the ARM64 build has no assembler input.
+    configure_args.push("-DWAMR_BUILD_INVOKE_NATIVE_GENERAL=1".to_string());
+  }
+  if target_os == "windows" && target_env == "msvc" {
+    // Keep WAMR's C runtime linkage aligned with Rust. In particular, Deno
+    // enables crt-static and otherwise gets a mixture of /MT and /MD objects.
+    let target_features =
+      env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
+    let runtime = if target_features.split(',').any(|f| f == "crt-static") {
+      "MultiThreaded"
+    } else {
+      "MultiThreadedDLL"
+    };
+    configure_args.push("-DCMAKE_POLICY_DEFAULT_CMP0091=NEW".to_string());
+    configure_args.push(format!("-DCMAKE_MSVC_RUNTIME_LIBRARY={runtime}"));
+  }
+  configure_args.push(src.to_string_lossy().into_owned());
+  let configure_arg_refs = configure_args
+    .iter()
+    .map(String::as_str)
+    .collect::<Vec<_>>();
+  cmake(&configure_arg_refs);
   // `--config` matters only for multi-config generators (the Visual Studio
   // default on Windows, which emits into a Release/ subdir); single-config
   // generators ignore it.

--- a/patches/wamr-09-skip-armasm-for-general-invoke.patch
+++ b/patches/wamr-09-skip-armasm-for-general-invoke.patch
@@ -1,0 +1,13 @@
+diff --git a/core/iwasm/common/iwasm_common.cmake b/core/iwasm/common/iwasm_common.cmake
+--- a/core/iwasm/common/iwasm_common.cmake
++++ b/core/iwasm/common/iwasm_common.cmake
+@@ -4,7 +4,8 @@
+ set (IWASM_COMMON_DIR ${CMAKE_CURRENT_LIST_DIR})
+ 
+ include_directories (${IWASM_COMMON_DIR})
+-if (MSVC AND WAMR_BUILD_PLATFORM STREQUAL "windows" AND WAMR_BUILD_TARGET MATCHES "AARCH64.*")
++if (MSVC AND WAMR_BUILD_PLATFORM STREQUAL "windows" AND WAMR_BUILD_TARGET MATCHES "AARCH64.*"
++    AND NOT WAMR_BUILD_INVOKE_NATIVE_GENERAL EQUAL 1)
+   if (DEFINED ENV{VCToolsInstallDir})
+     # Detect host tool dir
+     set(_ARMASM64_CANDIDATES

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -47,7 +47,16 @@ apply_series() {
       [ -f .cargo-ok ] || return 1
       echo "repairing stale Cargo submodule checkout: $sub"
       rm -rf -- "$sub" ".git/modules/$sub"
-      git -c "submodule.$sub.update=checkout" submodule update --init "$sub"
+      local initialized=false
+      for _ in 1 2 3; do
+        if git -c "submodule.$sub.update=checkout" submodule update --init "$sub"; then
+          initialized=true
+          break
+        fi
+        rm -f -- ".git/modules/$sub/index.lock"
+        sleep 1
+      done
+      [ "$initialized" = true ] || return 1
     fi
   fi
   mkdir -p "$stamp_dir"

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -46,7 +46,16 @@ apply_series() {
       # detached from stale submodule metadata. Never clean a normal checkout.
       [ -f .cargo-ok ] || return 1
       echo "repairing stale Cargo submodule checkout: $sub"
-      rm -rf -- "$sub" ".git/modules/$sub"
+      local cleared=false
+      for _ in {1..10}; do
+        rm -rf -- "$sub" ".git/modules/$sub"
+        if [ ! -e "$sub" ] && [ ! -e ".git/modules/$sub" ]; then
+          cleared=true
+          break
+        fi
+        sleep 1
+      done
+      [ "$cleared" = true ] || return 1
       local initialized=false
       for _ in 1 2 3; do
         if git -c "submodule.$sub.update=checkout" submodule update --init "$sub"; then

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -41,7 +41,14 @@ apply_series() {
   local sub="$1" prefix="$2"
   local stamp_dir="$sub/.v8x-patches"
   if [ ! -e "$sub/.git" ]; then
-    git -c "submodule.$sub.update=checkout" submodule update --init "$sub"
+    if ! git -c "submodule.$sub.update=checkout" submodule update --init "$sub"; then
+      # Cargo git checkouts may be restored with the source tree present but
+      # detached from stale submodule metadata. Never clean a normal checkout.
+      [ -f .cargo-ok ] || return 1
+      echo "repairing stale Cargo submodule checkout: $sub"
+      rm -rf -- "$sub" ".git/modules/$sub"
+      git -c "submodule.$sub.update=checkout" submodule update --init "$sub"
+    fi
   fi
   mkdir -p "$stamp_dir"
   while IFS= read -r p; do


### PR DESCRIPTION
## Summary

- select the WAMR build target from the Cargo target architecture
- align the WAMR MSVC runtime with the Rust `crt-static` target feature
- use the portable WAMR native-call bridge on Windows ARM64, avoiding the unsupported MASM path
- recover stale vendored submodules only inside Cargo-owned git checkouts
- cover x86_64 dynamic/static CRT, native ARM64 static-CRT, and stale Cargo-checkout recovery in Windows CI
- link a test executable so CRT mismatches are detected inside v8x CI

## Root cause

The Deno Windows release jobs exposed configurations the existing v8x Windows check did not cover:

- On native ARM64, WAMR fails to recognize the CMake processor spelling and falls back to X86_64 assembly.
- Once AARCH64 is selected, Visual Studio ASM_MASM integration still invokes x86 MASM, which is unsupported on the native ARM64 runner and ignores the armasm64 compiler override.
- On x86_64, Deno enables the Rust `crt-static` target feature while WAMR retained the CMake default dynamic CRT. The mixed `/MT` and `/MD` objects leave `__imp_strtok_s` unresolved when a downstream executable links.
- Cargo cache restoration can leave a populated vendor worktree with missing or stale submodule metadata. The deferred build-script initialization then fails before compilation on both Windows and Linux.

The recovery is deliberately limited to Cargo-owned checkouts marked by `.cargo-ok`; normal source checkouts are never discarded automatically.

## Validation

The expanded Windows matrix reproduces the Deno x86_64 and ARM64 release configurations, links the library test executable, and injects stale Cargo submodule state to exercise recovery.
