### PR TITLE
ci: publish v8x to crates.io on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Publish to crates.io
+
+# Publishes the `v8x` crate to crates.io when a version tag is pushed, so
+# releasing no longer depends on one person running `cargo publish` locally.
+#
+# Release flow:
+#   1. Bump `version` in Cargo.toml and land it on main (CI green).
+#   2. Tag that commit with `v<version>` and push the tag, e.g.
+#        git tag v149.4.0-rc.1 && git push origin v149.4.0-rc.1
+#   3. This workflow verifies the tag matches Cargo.toml and publishes.
+#
+# Requires a repository secret `CARGO_REGISTRY_TOKEN`: a crates.io API token
+# (scoped to publish-new + publish-update for `v8x`). Add it once with:
+#   gh secret set CARGO_REGISTRY_TOKEN -R littledivy/v8x
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+# Never run two publishes for the same tag concurrently.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: cargo publish
+    runs-on: ubuntu-latest
+    steps:
+      # The crate's `include = [...]` curates the packaged files to in-repo
+      # sources only (the multi-GB vendored submodules are excluded on
+      # purpose), so `cargo package` does not need submodules checked out.
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify tag matches Cargo.toml version
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME#v}"
+          crate="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name=="v8x") | .version')"
+          echo "tag=$tag  crate=$crate"
+          if [ "$tag" != "$crate" ]; then
+            echo "::error::pushed tag 'v$tag' does not match Cargo.toml version '$crate' — aborting publish"
+            exit 1
+          fi
+
+      # --no-verify: verification would rebuild V8 from the vendored sources we
+      # intentionally skip above (multi-hour, needs submodules). The commit the
+      # tag points at is already gated by the CI workflow, so we package and
+      # upload without re-building here.
+      - name: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --no-verify --locked


### PR DESCRIPTION
## What

Adds a tag-triggered `Publish to crates.io` workflow so cutting a release no longer depends on someone running `cargo publish` locally.

## How it works

- Trigger: pushing a tag matching `v*`.
- Guards: the workflow reads the crate version via `cargo metadata` and **fails if the tag does not match** (e.g. `v149.4.0-rc.1` must match `version` in Cargo.toml), so a typo/wrong tag never publishes.
- Publish: `cargo publish --no-verify --locked`. `--no-verify` is used because verification would rebuild V8 from the vendored submodules (multi-hour, and those submodules are intentionally excluded from the package `include`). Correctness is already gated by the CI workflow on the tagged commit.

## One-time setup required (only you can do this)

Add a crates.io API token as a repo secret:

```sh
gh secret set CARGO_REGISTRY_TOKEN -R littledivy/v8x
```

(Create a token at https://crates.io/settings/tokens scoped to publish-new + publish-update for `v8x`.)

## Release flow after merge

```sh
# bump version in Cargo.toml, land on main (CI green), then:
git tag v149.4.0-rc.1
git push origin v149.4.0-rc.1
```