### PR TITLE
fix(build): reset recovered Cargo submodules

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -241,6 +241,21 @@ fn remove_stale_submodule_dir(path: &Path) {
   }
 }
 
+fn reset_repaired_submodule(root: &Path, sub: &str) {
+  let sub_dir = root.join(sub);
+  assert!(
+    run_git(
+      &sub_dir,
+      &["-c", "core.autocrlf=false", "reset", "--hard", "HEAD"]
+    ),
+    "failed to reset repaired Cargo submodule {sub}"
+  );
+  assert!(
+    run_git(&sub_dir, &["clean", "-ffdx"]),
+    "failed to clean repaired Cargo submodule {sub}"
+  );
+}
+
 fn initialize_submodule(root: &Path, sub: &str) {
   let update_cfg = format!("submodule.{sub}.update=checkout");
   let update = || {
@@ -263,6 +278,9 @@ fn initialize_submodule(root: &Path, sub: &str) {
     )
   };
   if update() {
+    if root.join(".cargo-ok").is_file() {
+      reset_repaired_submodule(root, sub);
+    }
     return;
   }
 
@@ -282,6 +300,7 @@ fn initialize_submodule(root: &Path, sub: &str) {
   let index_lock = root.join(".git/modules").join(sub).join("index.lock");
   for attempt in 1..=3 {
     if update() {
+      reset_repaired_submodule(root, sub);
       return;
     }
     // Git for Windows may return before a failed submodule helper has removed

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -66,6 +66,8 @@ apply_series() {
         sleep 1
       done
       [ "$initialized" = true ] || return 1
+      git -c core.autocrlf=false -C "$sub" reset --hard HEAD
+      git -C "$sub" clean -ffdx
     fi
   fi
   mkdir -p "$stamp_dir"


### PR DESCRIPTION
## Summary

- hard-reset and fully clean newly recovered Cargo-owned submodules before applying v8x patches
- preserve LF checkout semantics while resetting on Windows
- keep normal source checkouts untouched

## Root cause

The recovery merged in #70 can reinitialize a stale Cargo git checkout, but Git for Windows may internally retry a failed submodule clone and leave the recovered worktree partially modified. v8x then sees patch 02 as neither clean nor fully applied and aborts Deno QuickJS release packaging.

The reset is limited to initialization inside Cargo-owned checkouts marked by `.cargo-ok`, after stale recovery has already been selected.

## Validation

- `bash -n tools/setup_vendor.sh`
- the Windows x64 dynamic CI fixture holds stale submodule metadata open until recovery starts, then verifies recovery and link completion
- Deno full release CI pins this exact commit for Windows x64 and ARM64 artifact builds
